### PR TITLE
✨ feat(cv): add hyperlinks, promotion, and cleanup

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/main.tex
+++ b/main.tex
@@ -49,8 +49,9 @@
     \begin{alignat*}{100}
       \mbox{+}1\mbox{--}747\mbox{--}777\mbox{--}0357 \mbox{\hspace{0.1cm}} & \Diamond
       \mbox{\hspace{0.1cm}gaborjbernat@gmail.com} \\
-      \mbox{https://bernat.tech} \mbox{\hspace{0.1cm}}                      & \Diamond
-      \mbox{\hspace{0.1cm}Los Angeles, USA}
+      \mbox{\href{https://bernat.tech}{bernat.tech}} \mbox{\hspace{0.1cm}} & \Diamond
+      \mbox{\hspace{0.1cm}\href{https://github.com/gaborbernat}{github.com/gaborbernat}} \\
+      \mbox{Los Angeles, USA}
     \end{alignat*}
   \end{center}
 \end{minipage}
@@ -110,7 +111,8 @@ type generation from schemas, HTTP client libraries, and Jenkins CI pipeline lib
 \vskip\bigskipamount %
 
 \twoColumns{2016 April--2022 June}{ \textbf{Bloomberg} }
-\twoColumns{London, United Kingdom}{ \emph{Senior Software Engineer -- Data Technologies, Quality Control} }
+\twoColumns{London, United Kingdom}{ \emph{Software Engineer $\rightarrow$ Senior (2019) -- Data
+Technologies, Quality Control} }
 
 Core developer of the Business Rule Engine (BRE), a Python framework enabling financial analysts to author heuristic
 and statistical validation rules over a microservice platform. The system automatically collected metadata for
@@ -142,17 +144,26 @@ Created reStructuredText tutorials for the OpenCV library and helped architect i
 \vskip\medskipamount %
 
 \twoColumns{2015--present}{ \textbf{Open source software developer} }
-\twoColumns{}{https://bernat.tech/about}
+\twoColumns{}{\href{https://bernat.tech/about}{bernat.tech/about}}
 
-Author and primary maintainer of 30+ Python open source projects. Maintainer of virtualenv (since 2018, rewrote and
-re-released in 2020) and tox (since 2017, completed full rewrite as tox 4). Other high-profile projects: pipx, build,
-filelock, platformdirs, pipdeptree, pytest-env, pyproject-fmt, tox-uv, pre-commit-uv. Co-maintains Bloomberg open
-source projects pytest-memray and attrs-strict. Authored JetBrains plugins PyVenvManage and jetbrains-fish.
+Author and primary maintainer of 30+ Python open source projects. Maintainer of
+\href{https://github.com/pypa/virtualenv}{virtualenv} (since 2018, rewrote and re-released in 2020) and
+\href{https://github.com/tox-dev/tox}{tox} (since 2017, completed full rewrite as tox 4). Other high-profile projects:
+\href{https://github.com/pypa/pipx}{pipx}, \href{https://github.com/pypa/build}{build},
+\href{https://github.com/tox-dev/filelock}{filelock}, \href{https://github.com/tox-dev/platformdirs}{platformdirs},
+\href{https://github.com/tox-dev/pipdeptree}{pipdeptree}, \href{https://github.com/pytest-dev/pytest-env}{pytest-env},
+\href{https://github.com/tox-dev/pyproject-fmt}{pyproject-fmt}, \href{https://github.com/tox-dev/tox-uv}{tox-uv},
+\href{https://github.com/tox-dev/pre-commit-uv}{pre-commit-uv}. Co-maintains Bloomberg open source projects
+\href{https://github.com/bloomberg/pytest-memray}{pytest-memray} and
+\href{https://github.com/bloomberg/attrs-strict}{attrs-strict}. Authored JetBrains plugins
+\href{https://github.com/tox-dev/PyVenvManage}{PyVenvManage} and
+\href{https://github.com/tox-dev/jetbrains-fish}{jetbrains-fish}.
 
 Involved in Python packaging standards (PEP-517, 518, 660, 662). Recent work includes Python/Rust projects
-(pyproject-fmt, toml-fmt). Python Software Foundation Fellow (2021 Q3). Technical reviewer for ''Python Object-Oriented
-Programming 4th edition'' by Steven Lott and Dusty Phillips. Blog post series on Python type hints and packaging
-reached number one on Hacker News.
+(\href{https://github.com/tox-dev/pyproject-fmt}{pyproject-fmt},
+\href{https://github.com/tox-dev/toml-fmt}{toml-fmt}). Python Software Foundation Fellow (2021 Q3). Technical reviewer
+for ''Python Object-Oriented Programming 4th edition'' by Steven Lott and Dusty Phillips. Blog post series on Python
+type hints and packaging reached number one on Hacker News.
 
 \section*{\MakeUppercase{Education}}
 \leaders\vrule width \textwidth\vskip0.3pt % or other desired thickness
@@ -179,7 +190,8 @@ Thesis: "Regional segmentation of images with B--Spline level set models".
   \textbf{Languages}      & \emph{Python} (primary), TypeScript, Java, Kotlin, Rust, Go, Bash,
   Fish, C/C$++$, LaTeX            \\
   \textbf{Frameworks}     & FastAPI, React, Flask                                                                 \\
-  \textbf{Infrastructure} & Docker, Kubernetes, Redis, PostgreSQL, GitHub Actions, Jenkins                         \\
+  \textbf{Infrastructure} & Docker, Kubernetes, Redis, Kafka, PostgreSQL, GitHub Actions, Jenkins
+  \\
   \textbf{Tools}          & git, vim, tox, uv, ruff, pyright, VS Code, IntelliJ IDEA                              \\
   \textbf{Specialties}    & Developer tooling, packaging, static analysis, distributed systems, data pipelines     \\
 \end{tabular}


### PR DESCRIPTION
Follow-up to #12. The merged CV lacked clickable links and didn't show career progression within Bloomberg.

Added GitHub profile link (`github.com/gaborbernat`) to the header alongside email and website. Made all 15 OSS project mentions clickable `\href` links (virtualenv, tox, pipx, build, filelock, platformdirs, pipdeptree, pytest-env, pyproject-fmt, tox-uv, pre-commit-uv, pytest-memray, attrs-strict, PyVenvManage, jetbrains-fish, toml-fmt). The `bernat.tech/about` link in the Open Source section is now also clickable.

Bloomberg London role now shows promotion: "Software Engineer → Senior (2019)" instead of just "Senior Software Engineer," which better reflects career growth. Added Kafka to the Infrastructure row in Technical Strengths. Removed the duplicate `dependabot.yml` at the repo root (the correct one already exists at `.github/dependabot.yml`).