### PR TITLE
🔧 chore(cv): polish LaTeX source and add links

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -2,8 +2,8 @@
 
 \usepackage[pdftex]{graphicx}% Adds the ability to include images
 \usepackage[margin=2.5cm, top=1cm, a4paper]{geometry}
-\usepackage[T1]    {fontenc }% Allow accented output charachters
-\usepackage[utf8]  {inputenc}% Allow accented input charachters
+\usepackage[T1]    {fontenc }% Allow accented output characters
+\usepackage[utf8]  {inputenc}% Allow accented input characters
 \usepackage    {xcolor   }% Colors are fun :)
 \usepackage{array}
 \usepackage        {lmodern }% Modern output font
@@ -13,7 +13,6 @@
 \usepackage{sectsty}
 \usepackage{hyperref}
 \usepackage{dashrule}
-\usepackage{graphicx}
 
 \definecolor{lightgray}{gray}{0.8}
 
@@ -51,7 +50,9 @@
       \mbox{\hspace{0.1cm}gaborjbernat@gmail.com} \\
       \mbox{\href{https://bernat.tech}{bernat.tech}} \mbox{\hspace{0.1cm}} & \Diamond
       \mbox{\hspace{0.1cm}\href{https://github.com/gaborbernat}{github.com/gaborbernat}} \\
-      \mbox{Los Angeles, USA}
+      \mbox{\href{https://www.linkedin.com/in/gaborbernat}{linkedin.com/in/gaborbernat}}
+      \mbox{\hspace{0.1cm}} & \Diamond
+      \mbox{\hspace{0.1cm}Los Angeles, USA}
     \end{alignat*}
   \end{center}
 \end{minipage}
@@ -67,8 +68,9 @@ Senior software engineer at Bloomberg, working remotely from Los Angeles since 2
 spanning data ingestion pipelines, quality control systems, developer tooling, and open source leadership. Leads
 cross-cutting initiatives in Python packaging, developer experience, and platform engineering.
 Maintains 30+ Python ecosystem projects including virtualenv, tox, build, pipx,
-and pipdeptree. Python Software Foundation Fellow (2021). Delivered 15+ talks at PyCon US, EuroPython, PyTexas, and
-PyLondinium (2018--2025) on packaging standards, virtual environments, type hints, and Python--Rust interoperability.
+and pipdeptree. Python Software Foundation Fellow (2021). Delivered
+\href{https://bernat.tech/presentations}{15+ talks} at PyCon US, EuroPython, PyTexas, and PyLondinium
+(2018--2025) on packaging standards, virtual environments, type hints, and Python--Rust interoperability.
 
 \section*{\MakeUppercase{Experience}}
 \leaders\vrule width \textwidth\vskip0.3pt % or other desired thickness


### PR DESCRIPTION
Follow-up to #14. Added LinkedIn profile link (`linkedin.com/in/gaborbernat`) to the header and made the "15+ talks" mention in the summary a clickable link to `bernat.tech/presentations` with the full YouTube playlist.

Fixed "charachters" typos in LaTeX comments and removed the duplicate `\usepackage{graphicx}` import (line 3 already loads it via the `pdftex` driver option).