### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
   schedule:
     - cron: "0 8 * * *"
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to workflow files
- Satisfies the `actions/missing-workflow-permissions` code scanning rule
